### PR TITLE
Add configurable asset sort order (filename or date)

### DIFF
--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -584,6 +584,13 @@ func albumToResponse(a *domain.Album, opts albumResponseOpts, offset, limit int)
 		}
 	}
 
+	// Sort visible assets according to album config.
+	sortOrder := ""
+	if cfg, ok := opts.configs[a.Path]; ok {
+		sortOrder = cfg.SortOrder
+	}
+	sortAssets(visible, sortOrder)
+
 	total := len(visible)
 
 	// Clamp offset.

--- a/backend/internal/api/assets.go
+++ b/backend/internal/api/assets.go
@@ -11,19 +11,32 @@ import (
 	"github.com/perrito666/gollery/backend/internal/domain"
 )
 
+// sortAssets sorts a slice of assets in place according to sortOrder.
+// Valid values are "date" (sort by ModTime ascending) and anything else
+// (including "" and "filename") which sorts by filename ascending.
+func sortAssets(assets []domain.Asset, sortOrder string) {
+	switch sortOrder {
+	case "date":
+		sort.Slice(assets, func(i, j int) bool {
+			return assets[i].ModTime.Before(assets[j].ModTime)
+		})
+	default:
+		sort.Slice(assets, func(i, j int) bool {
+			return assets[i].Filename < assets[j].Filename
+		})
+	}
+}
+
 // findAdjacentAssets returns the previous and next asset IDs relative to
-// assetID within the album's asset list, sorted by filename.
-func findAdjacentAssets(album *domain.Album, assetID string) (prev, next *string) {
+// assetID within the album's asset list, sorted according to sortOrder.
+func findAdjacentAssets(album *domain.Album, assetID string, sortOrder string) (prev, next *string) {
 	if len(album.Assets) <= 1 {
 		return nil, nil
 	}
 
-	// Build sorted list of assets by filename.
 	sorted := make([]domain.Asset, len(album.Assets))
 	copy(sorted, album.Assets)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].Filename < sorted[j].Filename
-	})
+	sortAssets(sorted, sortOrder)
 
 	for i, a := range sorted {
 		if a.ID == assetID {
@@ -61,7 +74,11 @@ func (s *Server) handleAssetByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prev, next := findAdjacentAssets(album, asset.ID)
+	sortOrder := ""
+	if cfg, ok := s.configs[asset.AlbumPath]; ok {
+		sortOrder = cfg.SortOrder
+	}
+	prev, next := findAdjacentAssets(album, asset.ID, sortOrder)
 	resp := AssetResponse{
 		ID:          asset.ID,
 		Filename:    asset.Filename,

--- a/backend/internal/api/navigation_test.go
+++ b/backend/internal/api/navigation_test.go
@@ -41,6 +41,32 @@ func navSnapshot() (*domain.Snapshot, map[string]*config.AlbumConfig) {
 	return snap, configs
 }
 
+func navSnapshotDateSorted() (*domain.Snapshot, map[string]*config.AlbumConfig) {
+	t1 := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC) // newest
+	t2 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) // oldest
+	t3 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC) // middle
+
+	snap := &domain.Snapshot{
+		GeneratedAt: time.Now(),
+		Albums: map[string]*domain.Album{
+			"photos": {
+				ID:    "alb_photos",
+				Path:  "photos",
+				Title: "Photos",
+				Assets: []domain.Asset{
+					{ID: "ast_b", Filename: "bravo.jpg", AlbumPath: "photos", ModTime: t1},
+					{ID: "ast_a", Filename: "alpha.jpg", AlbumPath: "photos", ModTime: t2},
+					{ID: "ast_c", Filename: "charlie.jpg", AlbumPath: "photos", ModTime: t3},
+				},
+			},
+		},
+	}
+	configs := map[string]*config.AlbumConfig{
+		"photos": {Title: "Photos", Access: &config.AccessConfig{View: "public"}, SortOrder: "date"},
+	}
+	return snap, configs
+}
+
 func TestAsset_PrevNext_Middle(t *testing.T) {
 	snap, configs := navSnapshot()
 	srv := NewServer(snap, configs)
@@ -106,6 +132,53 @@ func TestAsset_PrevNext_Last(t *testing.T) {
 	}
 	if resp.NextAssetID != nil {
 		t.Errorf("next = %v, want nil", *resp.NextAssetID)
+	}
+}
+
+func TestAsset_PrevNext_DateSorted(t *testing.T) {
+	snap, configs := navSnapshotDateSorted()
+	srv := NewServer(snap, configs)
+	handler := srv.Handler()
+
+	// Date order: alpha(Jan1) -> charlie(Jan2) -> bravo(Jan3)
+	// charlie is in the middle when sorted by date
+	rr := doRequest(handler, "GET", "/api/v1/assets/ast_c", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var resp AssetResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.PrevAssetID == nil || *resp.PrevAssetID != "ast_a" {
+		t.Errorf("prev = %v, want ast_a (alpha, oldest)", resp.PrevAssetID)
+	}
+	if resp.NextAssetID == nil || *resp.NextAssetID != "ast_b" {
+		t.Errorf("next = %v, want ast_b (bravo, newest)", resp.NextAssetID)
+	}
+}
+
+func TestAsset_PrevNext_DateSorted_First(t *testing.T) {
+	snap, configs := navSnapshotDateSorted()
+	srv := NewServer(snap, configs)
+	handler := srv.Handler()
+
+	// alpha is oldest (first when sorted by date)
+	rr := doRequest(handler, "GET", "/api/v1/assets/ast_a", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var resp AssetResponse
+	json.NewDecoder(rr.Body).Decode(&resp)
+
+	if resp.PrevAssetID != nil {
+		t.Errorf("prev = %v, want nil (first in date order)", *resp.PrevAssetID)
+	}
+	if resp.NextAssetID == nil || *resp.NextAssetID != "ast_c" {
+		t.Errorf("next = %v, want ast_c", resp.NextAssetID)
 	}
 }
 

--- a/backend/internal/api/pagination_test.go
+++ b/backend/internal/api/pagination_test.go
@@ -136,6 +136,96 @@ func TestPagination_LimitCapped(t *testing.T) {
 	}
 }
 
+func TestPagination_DateSortOrder(t *testing.T) {
+	t1 := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	snap := &domain.Snapshot{
+		GeneratedAt: time.Now(),
+		Albums: map[string]*domain.Album{
+			"photos": {
+				ID: "alb_photos", Path: "photos", Title: "Photos",
+				Assets: []domain.Asset{
+					{ID: "ast_c", Filename: "charlie.jpg", AlbumPath: "photos", ModTime: t1},
+					{ID: "ast_a", Filename: "alpha.jpg", AlbumPath: "photos", ModTime: t2},
+					{ID: "ast_b", Filename: "bravo.jpg", AlbumPath: "photos", ModTime: t3},
+				},
+			},
+		},
+	}
+	configs := map[string]*config.AlbumConfig{
+		"photos": {Access: &config.AccessConfig{View: "public"}, SortOrder: "date"},
+	}
+
+	srv := NewServer(snap, configs)
+	handler := srv.Handler()
+
+	rr := doRequest(handler, "GET", "/api/v1/albums/alb_photos", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var resp AlbumResponse
+	json.NewDecoder(rr.Body).Decode(&resp)
+
+	// Date order: alpha(Jan1), bravo(Jan2), charlie(Jan3)
+	if len(resp.Assets) != 3 {
+		t.Fatalf("assets len = %d, want 3", len(resp.Assets))
+	}
+	if resp.Assets[0].ID != "ast_a" {
+		t.Errorf("first asset = %s, want ast_a (oldest)", resp.Assets[0].ID)
+	}
+	if resp.Assets[1].ID != "ast_b" {
+		t.Errorf("second asset = %s, want ast_b (middle)", resp.Assets[1].ID)
+	}
+	if resp.Assets[2].ID != "ast_c" {
+		t.Errorf("third asset = %s, want ast_c (newest)", resp.Assets[2].ID)
+	}
+}
+
+func TestPagination_DefaultSortIsFilename(t *testing.T) {
+	t1 := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	snap := &domain.Snapshot{
+		GeneratedAt: time.Now(),
+		Albums: map[string]*domain.Album{
+			"photos": {
+				ID: "alb_photos", Path: "photos", Title: "Photos",
+				Assets: []domain.Asset{
+					{ID: "ast_c", Filename: "charlie.jpg", AlbumPath: "photos", ModTime: t1},
+					{ID: "ast_a", Filename: "alpha.jpg", AlbumPath: "photos", ModTime: t2},
+					{ID: "ast_b", Filename: "bravo.jpg", AlbumPath: "photos", ModTime: t3},
+				},
+			},
+		},
+	}
+	// No sort_order set — should default to filename.
+	configs := map[string]*config.AlbumConfig{
+		"photos": {Access: &config.AccessConfig{View: "public"}},
+	}
+
+	srv := NewServer(snap, configs)
+	handler := srv.Handler()
+
+	rr := doRequest(handler, "GET", "/api/v1/albums/alb_photos", nil)
+	var resp AlbumResponse
+	json.NewDecoder(rr.Body).Decode(&resp)
+
+	// Filename order: alpha, bravo, charlie
+	if resp.Assets[0].ID != "ast_a" {
+		t.Errorf("first asset = %s, want ast_a (alpha)", resp.Assets[0].ID)
+	}
+	if resp.Assets[1].ID != "ast_b" {
+		t.Errorf("second asset = %s, want ast_b (bravo)", resp.Assets[1].ID)
+	}
+	if resp.Assets[2].ID != "ast_c" {
+		t.Errorf("third asset = %s, want ast_c (charlie)", resp.Assets[2].ID)
+	}
+}
+
 func TestPagination_RootAlbum(t *testing.T) {
 	snap, configs := paginationSnapshot()
 	srv := NewServer(snap, configs)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -97,6 +97,10 @@ type AlbumConfig struct {
 
 	// Derivatives defines default derivative generation settings.
 	Derivatives *DerivativesConfig `json:"derivatives,omitempty"`
+
+	// SortOrder controls how assets are ordered when listing an album.
+	// Valid values: "filename" (default), "date" (sort by file modification time).
+	SortOrder string `json:"sort_order,omitempty"`
 }
 
 // AccessConfig defines visibility and ACL rules.
@@ -135,6 +139,13 @@ var ValidAccessModes = map[string]bool{
 	"restricted":    true,
 }
 
+// ValidSortOrders lists the allowed values for AlbumConfig.SortOrder.
+var ValidSortOrders = map[string]bool{
+	"":         true, // empty means default (filename)
+	"filename": true,
+	"date":     true,
+}
+
 // LoadAlbumConfig reads and parses an album.json file.
 func LoadAlbumConfig(path string) (*AlbumConfig, error) {
 	data, err := os.ReadFile(path)
@@ -164,6 +175,9 @@ func (c *AlbumConfig) Validate() error {
 		if !ValidAccessModes[c.Access.View] {
 			return fmt.Errorf("invalid access mode: %q", c.Access.View)
 		}
+	}
+	if !ValidSortOrders[c.SortOrder] {
+		return fmt.Errorf("invalid sort_order: %q", c.SortOrder)
 	}
 	return nil
 }
@@ -197,6 +211,9 @@ func MergeAlbumConfigs(parent, child *AlbumConfig) *AlbumConfig {
 	}
 	if child.Description != "" {
 		merged.Description = child.Description
+	}
+	if child.SortOrder != "" {
+		merged.SortOrder = child.SortOrder
 	}
 	merged.Inherit = child.Inherit
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -84,6 +84,23 @@ func TestAlbumConfigValidate(t *testing.T) {
 			cfg:     AlbumConfig{Access: &AccessConfig{View: "secret"}},
 			wantErr: true,
 		},
+		{
+			name: "valid sort_order filename",
+			cfg:  AlbumConfig{SortOrder: "filename"},
+		},
+		{
+			name: "valid sort_order date",
+			cfg:  AlbumConfig{SortOrder: "date"},
+		},
+		{
+			name: "valid sort_order empty",
+			cfg:  AlbumConfig{SortOrder: ""},
+		},
+		{
+			name:    "invalid sort_order",
+			cfg:     AlbumConfig{SortOrder: "random"},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -175,6 +192,23 @@ func TestMergeAlbumConfigs_InheritFalse(t *testing.T) {
 	}
 	if merged.Description != "" {
 		t.Errorf("description = %q, want empty (inherit=false)", merged.Description)
+	}
+}
+
+func TestMergeAlbumConfigs_SortOrderInheritance(t *testing.T) {
+	parent := &AlbumConfig{SortOrder: "date"}
+	child := &AlbumConfig{Title: "Child"}
+
+	merged := MergeAlbumConfigs(parent, child)
+	if merged.SortOrder != "date" {
+		t.Errorf("sort_order = %q, want %q (inherited from parent)", merged.SortOrder, "date")
+	}
+
+	// Child overrides parent.
+	child2 := &AlbumConfig{SortOrder: "filename"}
+	merged2 := MergeAlbumConfigs(parent, child2)
+	if merged2.SortOrder != "filename" {
+		t.Errorf("sort_order = %q, want %q (overridden by child)", merged2.SortOrder, "filename")
 	}
 }
 


### PR DESCRIPTION
Albums default to sorting assets by filename. Setting "sort_order": "date" in album.json sorts by file modification time instead. The setting inherits from parent albums and affects both album listings and prev/next navigation.