### PR TITLE
Add geo: URI map links for assets with GPS coordinates

### DIFF
--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -102,6 +102,7 @@ type AssetSummary struct {
 	Filename    string `json:"filename"`
 	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
+	HasLocation bool   `json:"has_location,omitempty"`
 }
 
 // AssetResponse is the JSON representation of an asset.
@@ -115,6 +116,7 @@ type AssetResponse struct {
 	SizeBytes   int64   `json:"size_bytes"`
 	PrevAssetID *string `json:"prev_asset_id"`
 	NextAssetID *string `json:"next_asset_id"`
+	GeoURI      *string `json:"geo_uri,omitempty"`
 }
 
 // MetadataPatchRequest is the JSON body for PATCH /api/v1/assets/{id}/metadata
@@ -617,7 +619,11 @@ func albumToResponse(a *domain.Album, opts albumResponseOpts, offset, limit int)
 	page := visible[offset:end]
 	assets := make([]AssetSummary, len(page))
 	for i, ast := range page {
-		assets[i] = AssetSummary{ID: ast.ID, Filename: ast.Filename, Title: ast.Title, Description: ast.Description}
+		summary := AssetSummary{ID: ast.ID, Filename: ast.Filename, Title: ast.Title, Description: ast.Description}
+		if ast.Metadata != nil && ast.Metadata.Latitude != nil && ast.Metadata.Longitude != nil {
+			summary.HasLocation = true
+		}
+		assets[i] = summary
 	}
 
 	// Filter children the principal can view.

--- a/backend/internal/api/assets.go
+++ b/backend/internal/api/assets.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"log/slog"
 	"net/http"
 	"path/filepath"
@@ -10,6 +11,16 @@ import (
 	"github.com/perrito666/gollery/backend/internal/derive"
 	"github.com/perrito666/gollery/backend/internal/domain"
 )
+
+// formatGeoURI returns a geo: URI string for the given coordinates,
+// or nil if the asset has no location.
+func formatGeoURI(asset *domain.Asset) *string {
+	if asset.Metadata == nil || asset.Metadata.Latitude == nil || asset.Metadata.Longitude == nil {
+		return nil
+	}
+	uri := fmt.Sprintf("geo:%f,%f", *asset.Metadata.Latitude, *asset.Metadata.Longitude)
+	return &uri
+}
 
 // sortAssets sorts a slice of assets in place according to sortOrder.
 // Valid values are "date" (sort by ModTime ascending) and anything else
@@ -89,6 +100,7 @@ func (s *Server) handleAssetByID(w http.ResponseWriter, r *http.Request) {
 		SizeBytes:   asset.SizeBytes,
 		PrevAssetID: prev,
 		NextAssetID: next,
+		GeoURI:      formatGeoURI(asset),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/backend/internal/api/navigation_test.go
+++ b/backend/internal/api/navigation_test.go
@@ -202,3 +202,60 @@ func TestAsset_PrevNext_SingleAsset(t *testing.T) {
 		t.Errorf("next = %v, want nil", *resp.NextAssetID)
 	}
 }
+
+func TestAsset_GeoURI_Present(t *testing.T) {
+	lat, lon := 48.8566, 2.3522
+	snap := &domain.Snapshot{
+		GeneratedAt: time.Now(),
+		Albums: map[string]*domain.Album{
+			"geo": {
+				ID: "alb_geo", Path: "geo", Title: "Geo",
+				Assets: []domain.Asset{
+					{
+						ID: "ast_geo", Filename: "paris.jpg", AlbumPath: "geo",
+						Metadata: &domain.ImageMetadata{Latitude: &lat, Longitude: &lon},
+					},
+				},
+			},
+		},
+	}
+	configs := map[string]*config.AlbumConfig{
+		"geo": {Title: "Geo", Access: &config.AccessConfig{View: "public"}},
+	}
+
+	srv := NewServer(snap, configs)
+	handler := srv.Handler()
+
+	rr := doRequest(handler, "GET", "/api/v1/assets/ast_geo", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var resp AssetResponse
+	json.NewDecoder(rr.Body).Decode(&resp)
+
+	if resp.GeoURI == nil {
+		t.Fatal("expected geo_uri to be present")
+	}
+	if *resp.GeoURI != "geo:48.856600,2.352200" {
+		t.Errorf("geo_uri = %q, want %q", *resp.GeoURI, "geo:48.856600,2.352200")
+	}
+}
+
+func TestAsset_GeoURI_Absent(t *testing.T) {
+	snap, configs := navSnapshot()
+	srv := NewServer(snap, configs)
+	handler := srv.Handler()
+
+	rr := doRequest(handler, "GET", "/api/v1/assets/ast_a", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var resp AssetResponse
+	json.NewDecoder(rr.Body).Decode(&resp)
+
+	if resp.GeoURI != nil {
+		t.Errorf("expected no geo_uri, got %q", *resp.GeoURI)
+	}
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -101,6 +101,14 @@ type AlbumConfig struct {
 	// SortOrder controls how assets are ordered when listing an album.
 	// Valid values: "filename" (default), "date" (sort by file modification time).
 	SortOrder string `json:"sort_order,omitempty"`
+
+	// Latitude is the album-level default latitude for assets without
+	// individual GPS coordinates. Used as a fallback only.
+	Latitude *float64 `json:"latitude,omitempty"`
+
+	// Longitude is the album-level default longitude for assets without
+	// individual GPS coordinates. Used as a fallback only.
+	Longitude *float64 `json:"longitude,omitempty"`
 }
 
 // AccessConfig defines visibility and ACL rules.
@@ -214,6 +222,12 @@ func MergeAlbumConfigs(parent, child *AlbumConfig) *AlbumConfig {
 	}
 	if child.SortOrder != "" {
 		merged.SortOrder = child.SortOrder
+	}
+	if child.Latitude != nil {
+		merged.Latitude = child.Latitude
+	}
+	if child.Longitude != nil {
+		merged.Longitude = child.Longitude
 	}
 	merged.Inherit = child.Inherit
 

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -212,6 +212,37 @@ func TestMergeAlbumConfigs_SortOrderInheritance(t *testing.T) {
 	}
 }
 
+func float64Ptr(v float64) *float64 { return &v }
+
+func TestMergeAlbumConfigs_LatLonInheritance(t *testing.T) {
+	parent := &AlbumConfig{
+		Latitude:  float64Ptr(48.8566),
+		Longitude: float64Ptr(2.3522),
+	}
+	child := &AlbumConfig{Title: "Child"}
+
+	merged := MergeAlbumConfigs(parent, child)
+	if merged.Latitude == nil || *merged.Latitude != 48.8566 {
+		t.Errorf("latitude = %v, want 48.8566 (inherited)", merged.Latitude)
+	}
+	if merged.Longitude == nil || *merged.Longitude != 2.3522 {
+		t.Errorf("longitude = %v, want 2.3522 (inherited)", merged.Longitude)
+	}
+
+	// Child overrides parent.
+	child2 := &AlbumConfig{
+		Latitude:  float64Ptr(40.7128),
+		Longitude: float64Ptr(-74.0060),
+	}
+	merged2 := MergeAlbumConfigs(parent, child2)
+	if *merged2.Latitude != 40.7128 {
+		t.Errorf("latitude = %v, want 40.7128 (overridden)", *merged2.Latitude)
+	}
+	if *merged2.Longitude != -74.0060 {
+		t.Errorf("longitude = %v, want -74.0060 (overridden)", *merged2.Longitude)
+	}
+}
+
 func TestMergeAlbumConfigs_AnalyticsMerge(t *testing.T) {
 	parent := &AlbumConfig{
 		Analytics: &AlbumAnalyticsConfig{

--- a/backend/internal/fswalk/fswalk.go
+++ b/backend/internal/fswalk/fswalk.go
@@ -79,6 +79,9 @@ type ScannedAlbum struct {
 
 	// ChildPaths lists relative paths of direct child albums.
 	ChildPaths []string
+
+	// GPXFiles lists absolute paths to .gpx files found in this directory.
+	GPXFiles []string
 }
 
 // ScanResult holds the output of a content tree scan.
@@ -176,16 +179,17 @@ func Scan(contentRoot string) (*ScanResult, error) {
 
 		resolved[relPath] = cfg
 
-		// Scan for image assets in this directory.
-		assets, assetErr := scanAssets(absPath)
-		if assetErr != nil {
-			result.Errors = append(result.Errors, ScanError{Path: relPath, Err: assetErr})
+		// Scan for image assets and GPX files in this directory.
+		assets, gpxFiles, scanErr := scanDir(absPath)
+		if scanErr != nil {
+			result.Errors = append(result.Errors, ScanError{Path: relPath, Err: scanErr})
 		}
 
 		album := &ScannedAlbum{
-			Path:   relPath,
-			Config: cfg,
-			Assets: assets,
+			Path:     relPath,
+			Config:   cfg,
+			Assets:   assets,
+			GPXFiles: gpxFiles,
 		}
 		result.Albums[relPath] = album
 
@@ -209,19 +213,24 @@ func Scan(contentRoot string) (*ScanResult, error) {
 	return result, nil
 }
 
-// scanAssets reads a directory and returns recognized image files.
-func scanAssets(dirPath string) ([]ScannedAsset, error) {
+// scanDir reads a directory and returns recognized image files and GPX file paths.
+func scanDir(dirPath string) ([]ScannedAsset, []string, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var assets []ScannedAsset
+	var gpxFiles []string
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
 		ext := strings.ToLower(filepath.Ext(e.Name()))
+		if ext == ".gpx" {
+			gpxFiles = append(gpxFiles, filepath.Join(dirPath, e.Name()))
+			continue
+		}
 		if !ImageExtensions[ext] {
 			continue
 		}
@@ -235,5 +244,5 @@ func scanAssets(dirPath string) ([]ScannedAsset, error) {
 			SizeBytes: info.Size(),
 		})
 	}
-	return assets, nil
+	return assets, gpxFiles, nil
 }

--- a/backend/internal/fswalk/fswalk_test.go
+++ b/backend/internal/fswalk/fswalk_test.go
@@ -216,6 +216,33 @@ func TestScan_ChildPaths(t *testing.T) {
 	}
 }
 
+func TestScan_GPXFilesDiscovered(t *testing.T) {
+	root := t.TempDir()
+	writeAlbumJSON(t, root, `{"title": "Root"}`)
+	writeFile(t, filepath.Join(root, "photo.jpg"))
+	writeFile(t, filepath.Join(root, "track.gpx"))
+	writeFile(t, filepath.Join(root, "route.gpx"))
+
+	result, err := Scan(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	album := result.Albums[""]
+	if len(album.Assets) != 1 {
+		t.Errorf("expected 1 asset, got %d", len(album.Assets))
+	}
+	if len(album.GPXFiles) != 2 {
+		t.Errorf("expected 2 GPX files, got %d: %v", len(album.GPXFiles), album.GPXFiles)
+	}
+	// GPX files should be absolute paths.
+	for _, f := range album.GPXFiles {
+		if !filepath.IsAbs(f) {
+			t.Errorf("GPX path should be absolute: %s", f)
+		}
+	}
+}
+
 func TestScan_ImageExtensions(t *testing.T) {
 	root := t.TempDir()
 	writeAlbumJSON(t, root, `{"title": "Root"}`)

--- a/backend/internal/geo/gpx.go
+++ b/backend/internal/geo/gpx.go
@@ -1,0 +1,143 @@
+// Package geo provides GPS coordinate resolution from GPX tracklogs.
+package geo
+
+import (
+	"encoding/xml"
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"time"
+)
+
+// Trackpoint is a single GPS position with a timestamp.
+type Trackpoint struct {
+	Lat  float64
+	Lon  float64
+	Time time.Time
+}
+
+// gpxFile represents the top-level GPX XML structure.
+type gpxFile struct {
+	XMLName xml.Name `xml:"gpx"`
+	Tracks  []gpxTrk `xml:"trk"`
+}
+
+type gpxTrk struct {
+	Segments []gpxTrkSeg `xml:"trkseg"`
+}
+
+type gpxTrkSeg struct {
+	Points []gpxTrkPt `xml:"trkpt"`
+}
+
+type gpxTrkPt struct {
+	Lat  float64 `xml:"lat,attr"`
+	Lon  float64 `xml:"lon,attr"`
+	Time string  `xml:"time"`
+}
+
+// ParseGPXFiles reads one or more GPX files and returns all trackpoints
+// sorted by time. Points without a parseable timestamp are silently skipped.
+func ParseGPXFiles(paths []string) ([]Trackpoint, error) {
+	var all []Trackpoint
+	for _, path := range paths {
+		pts, err := parseOneGPX(path)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+		all = append(all, pts...)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Time.Before(all[j].Time)
+	})
+	return all, nil
+}
+
+func parseOneGPX(path string) ([]Trackpoint, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var gpx gpxFile
+	if err := xml.Unmarshal(data, &gpx); err != nil {
+		return nil, err
+	}
+
+	var pts []Trackpoint
+	for _, trk := range gpx.Tracks {
+		for _, seg := range trk.Segments {
+			for _, pt := range seg.Points {
+				t, err := time.Parse(time.RFC3339, pt.Time)
+				if err != nil {
+					// Try RFC3339Nano as fallback.
+					t, err = time.Parse(time.RFC3339Nano, pt.Time)
+					if err != nil {
+						continue
+					}
+				}
+				pts = append(pts, Trackpoint{
+					Lat:  pt.Lat,
+					Lon:  pt.Lon,
+					Time: t,
+				})
+			}
+		}
+	}
+	return pts, nil
+}
+
+// MatchNearest finds the best GPS coordinate for a given timestamp from a
+// sorted trackpoint slice. It first looks for the single closest point
+// within tolerance. If no single point qualifies but the timestamp falls
+// between two consecutive points, it linearly interpolates between them.
+// Returns ok=false if no match is possible.
+func MatchNearest(points []Trackpoint, t time.Time, tolerance time.Duration) (lat, lon float64, ok bool) {
+	if len(points) == 0 {
+		return 0, 0, false
+	}
+
+	// Binary search for the insertion point.
+	idx := sort.Search(len(points), func(i int) bool {
+		return !points[i].Time.Before(t)
+	})
+
+	// Check the nearest candidates (idx-1 and idx).
+	bestDist := time.Duration(math.MaxInt64)
+	bestIdx := -1
+
+	if idx > 0 {
+		d := t.Sub(points[idx-1].Time)
+		if d < bestDist {
+			bestDist = d
+			bestIdx = idx - 1
+		}
+	}
+	if idx < len(points) {
+		d := points[idx].Time.Sub(t)
+		if d < bestDist {
+			bestDist = d
+			bestIdx = idx
+		}
+	}
+
+	// Exact or near match within tolerance.
+	if bestIdx >= 0 && bestDist <= tolerance {
+		return points[bestIdx].Lat, points[bestIdx].Lon, true
+	}
+
+	// Interpolation: t falls between two consecutive points.
+	if idx > 0 && idx < len(points) {
+		before := points[idx-1]
+		after := points[idx]
+		span := after.Time.Sub(before.Time)
+		if span > 0 {
+			frac := float64(t.Sub(before.Time)) / float64(span)
+			lat = before.Lat + frac*(after.Lat-before.Lat)
+			lon = before.Lon + frac*(after.Lon-before.Lon)
+			return lat, lon, true
+		}
+	}
+
+	return 0, 0, false
+}

--- a/backend/internal/geo/gpx_test.go
+++ b/backend/internal/geo/gpx_test.go
@@ -1,0 +1,205 @@
+package geo
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const sampleGPX = `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk>
+    <trkseg>
+      <trkpt lat="48.8566" lon="2.3522">
+        <time>2024-06-15T10:00:00Z</time>
+      </trkpt>
+      <trkpt lat="48.8570" lon="2.3530">
+        <time>2024-06-15T10:01:00Z</time>
+      </trkpt>
+      <trkpt lat="48.8580" lon="2.3540">
+        <time>2024-06-15T10:02:00Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>`
+
+func writeGPX(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseGPXFiles_Basic(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGPX(t, dir, "track.gpx", sampleGPX)
+
+	pts, err := ParseGPXFiles([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pts) != 3 {
+		t.Fatalf("got %d points, want 3", len(pts))
+	}
+	if pts[0].Lat != 48.8566 || pts[0].Lon != 2.3522 {
+		t.Errorf("first point = (%f, %f), want (48.8566, 2.3522)", pts[0].Lat, pts[0].Lon)
+	}
+}
+
+func TestParseGPXFiles_Multiple(t *testing.T) {
+	dir := t.TempDir()
+	gpx2 := `<?xml version="1.0"?>
+<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="40.7128" lon="-74.0060">
+      <time>2024-06-15T09:00:00Z</time>
+    </trkpt>
+  </trkseg></trk>
+</gpx>`
+	p1 := writeGPX(t, dir, "a.gpx", sampleGPX)
+	p2 := writeGPX(t, dir, "b.gpx", gpx2)
+
+	pts, err := ParseGPXFiles([]string{p1, p2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pts) != 4 {
+		t.Fatalf("got %d points, want 4", len(pts))
+	}
+	// Should be sorted by time — NYC point (09:00) comes first.
+	if pts[0].Lat != 40.7128 {
+		t.Errorf("first point lat = %f, want 40.7128 (earliest)", pts[0].Lat)
+	}
+}
+
+func TestParseGPXFiles_InvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeGPX(t, dir, "bad.gpx", "not xml at all {{{")
+
+	_, err := ParseGPXFiles([]string{path})
+	if err == nil {
+		t.Error("expected error for invalid XML")
+	}
+}
+
+func TestParseGPXFiles_MissingFile(t *testing.T) {
+	_, err := ParseGPXFiles([]string{"/nonexistent/track.gpx"})
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestMatchNearest_ExactMatch(t *testing.T) {
+	pts := []Trackpoint{
+		{Lat: 48.8566, Lon: 2.3522, Time: time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)},
+		{Lat: 48.8570, Lon: 2.3530, Time: time.Date(2024, 6, 15, 10, 1, 0, 0, time.UTC)},
+	}
+
+	lat, lon, ok := MatchNearest(pts, pts[0].Time, 30*time.Second)
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if lat != 48.8566 || lon != 2.3522 {
+		t.Errorf("got (%f, %f), want (48.8566, 2.3522)", lat, lon)
+	}
+}
+
+func TestMatchNearest_WithinTolerance(t *testing.T) {
+	pts := []Trackpoint{
+		{Lat: 48.8566, Lon: 2.3522, Time: time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)},
+	}
+
+	// 20 seconds after — within 30s tolerance.
+	query := pts[0].Time.Add(20 * time.Second)
+	lat, lon, ok := MatchNearest(pts, query, 30*time.Second)
+	if !ok {
+		t.Fatal("expected match within tolerance")
+	}
+	if lat != 48.8566 {
+		t.Errorf("lat = %f, want 48.8566", lat)
+	}
+	_ = lon
+}
+
+func TestMatchNearest_OutsideTolerance_Interpolates(t *testing.T) {
+	t1 := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 6, 15, 10, 2, 0, 0, time.UTC) // 2 minutes apart
+
+	pts := []Trackpoint{
+		{Lat: 40.0, Lon: -74.0, Time: t1},
+		{Lat: 42.0, Lon: -72.0, Time: t2},
+	}
+
+	// Midpoint: 1 minute in.
+	query := t1.Add(1 * time.Minute)
+	lat, lon, ok := MatchNearest(pts, query, 30*time.Second)
+	if !ok {
+		t.Fatal("expected interpolated match")
+	}
+	if math.Abs(lat-41.0) > 0.001 {
+		t.Errorf("lat = %f, want ~41.0 (midpoint)", lat)
+	}
+	if math.Abs(lon-(-73.0)) > 0.001 {
+		t.Errorf("lon = %f, want ~-73.0 (midpoint)", lon)
+	}
+}
+
+func TestMatchNearest_OutsideTolerance_QuarterPoint(t *testing.T) {
+	t1 := time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 6, 15, 10, 4, 0, 0, time.UTC) // 4 minutes apart
+
+	pts := []Trackpoint{
+		{Lat: 40.0, Lon: -74.0, Time: t1},
+		{Lat: 44.0, Lon: -70.0, Time: t2},
+	}
+
+	// 1 minute in = 25% of the way.
+	query := t1.Add(1 * time.Minute)
+	lat, lon, ok := MatchNearest(pts, query, 30*time.Second)
+	if !ok {
+		t.Fatal("expected interpolated match")
+	}
+	if math.Abs(lat-41.0) > 0.001 {
+		t.Errorf("lat = %f, want ~41.0 (25%%)", lat)
+	}
+	if math.Abs(lon-(-73.0)) > 0.001 {
+		t.Errorf("lon = %f, want ~-73.0 (25%%)", lon)
+	}
+}
+
+func TestMatchNearest_BeforeAllPoints(t *testing.T) {
+	pts := []Trackpoint{
+		{Lat: 48.8566, Lon: 2.3522, Time: time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)},
+	}
+
+	// Way before the only point — no interpolation possible.
+	query := time.Date(2024, 6, 15, 9, 0, 0, 0, time.UTC)
+	_, _, ok := MatchNearest(pts, query, 30*time.Second)
+	if ok {
+		t.Error("expected no match for time far before all points")
+	}
+}
+
+func TestMatchNearest_AfterAllPoints(t *testing.T) {
+	pts := []Trackpoint{
+		{Lat: 48.8566, Lon: 2.3522, Time: time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)},
+	}
+
+	// Way after the only point.
+	query := time.Date(2024, 6, 15, 11, 0, 0, 0, time.UTC)
+	_, _, ok := MatchNearest(pts, query, 30*time.Second)
+	if ok {
+		t.Error("expected no match for time far after all points")
+	}
+}
+
+func TestMatchNearest_EmptyPoints(t *testing.T) {
+	_, _, ok := MatchNearest(nil, time.Now(), 30*time.Second)
+	if ok {
+		t.Error("expected no match for empty points")
+	}
+}

--- a/backend/internal/index/builder.go
+++ b/backend/internal/index/builder.go
@@ -37,13 +37,18 @@ package index
 
 import (
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"time"
 
 	"github.com/perrito666/gollery/backend/internal/domain"
 	"github.com/perrito666/gollery/backend/internal/fswalk"
+	"github.com/perrito666/gollery/backend/internal/geo"
+	"github.com/perrito666/gollery/backend/internal/meta"
 	"github.com/perrito666/gollery/backend/internal/state"
 )
+
+const gpxTolerance = 30 * time.Second
 
 // BuildSnapshot combines scanner output with sidecar state to produce
 // a point-in-time Snapshot with stable IDs and album hierarchy.
@@ -78,7 +83,25 @@ func BuildSnapshot(contentRoot string, scan *fswalk.ScanResult) (*domain.Snapsho
 			}
 		}
 
-		// Build assets with stable IDs.
+		// Parse GPX files for this album (once, shared across assets).
+		var gpxPoints []geo.Trackpoint
+		if len(scanned.GPXFiles) > 0 {
+			pts, err := geo.ParseGPXFiles(scanned.GPXFiles)
+			if err != nil {
+				slog.Warn("failed to parse GPX files", "album", relPath, "error", err)
+			} else {
+				gpxPoints = pts
+			}
+		}
+
+		// Album-level fallback coordinates from config.
+		var albumLat, albumLon *float64
+		if scanned.Config != nil {
+			albumLat = scanned.Config.Latitude
+			albumLon = scanned.Config.Longitude
+		}
+
+		// Build assets with stable IDs and resolve coordinates.
 		assets := make([]domain.Asset, 0, len(scanned.Assets))
 		for _, sa := range scanned.Assets {
 			assetState, _, err := state.EnsureAssetID(absPath, sa.Filename)
@@ -101,6 +124,26 @@ func BuildSnapshot(contentRoot string, scan *fswalk.ScanResult) (*domain.Snapsho
 					AllowedGroups: assetState.AccessOverride.AllowedGroups,
 				}
 			}
+
+			// Resolve GPS coordinates.
+			resolvedLat, resolvedLon := resolveCoords(
+				absPath, sa.Filename, assetState, gpxPoints,
+			)
+
+			if resolvedLat != nil && resolvedLon != nil {
+				asset.Metadata = &domain.ImageMetadata{
+					Latitude:  resolvedLat,
+					Longitude: resolvedLon,
+				}
+			} else if albumLat != nil && albumLon != nil {
+				// Album-level fallback (not persisted to asset sidecar).
+				lat, lon := *albumLat, *albumLon
+				asset.Metadata = &domain.ImageMetadata{
+					Latitude:  &lat,
+					Longitude: &lon,
+				}
+			}
+
 			assets = append(assets, asset)
 		}
 
@@ -117,4 +160,57 @@ func BuildSnapshot(contentRoot string, scan *fswalk.ScanResult) (*domain.Snapsho
 	}
 
 	return snap, nil
+}
+
+// resolveCoords attempts to resolve GPS coordinates for an asset.
+// It checks: cached sidecar → EXIF → GPX matching.
+// If coordinates are found (or all sources exhausted), it persists
+// the result to the sidecar and sets GeoResolved to avoid re-processing.
+func resolveCoords(
+	albumAbsPath, filename string,
+	assetState *state.AssetState,
+	gpxPoints []geo.Trackpoint,
+) (lat, lon *float64) {
+	// Already resolved — use cached result (may be nil if no coords found).
+	if assetState.GeoResolved {
+		return assetState.Latitude, assetState.Longitude
+	}
+
+	// Try EXIF extraction.
+	filePath := filepath.Join(albumAbsPath, filename)
+	exifMeta, err := meta.Extract(filePath)
+	if err != nil {
+		slog.Warn("EXIF extraction failed", "file", filename, "error", err)
+	}
+
+	if exifMeta != nil && exifMeta.Latitude != nil && exifMeta.Longitude != nil {
+		assetState.Latitude = exifMeta.Latitude
+		assetState.Longitude = exifMeta.Longitude
+		assetState.GeoResolved = true
+		if err := state.SaveAssetState(albumAbsPath, filename, assetState); err != nil {
+			slog.Warn("failed to save asset state with EXIF coords", "file", filename, "error", err)
+		}
+		return assetState.Latitude, assetState.Longitude
+	}
+
+	// Try GPX matching (requires DateTaken from EXIF).
+	if exifMeta != nil && exifMeta.DateTaken != nil && len(gpxPoints) > 0 {
+		glat, glon, ok := geo.MatchNearest(gpxPoints, *exifMeta.DateTaken, gpxTolerance)
+		if ok {
+			assetState.Latitude = &glat
+			assetState.Longitude = &glon
+			assetState.GeoResolved = true
+			if err := state.SaveAssetState(albumAbsPath, filename, assetState); err != nil {
+				slog.Warn("failed to save asset state with GPX coords", "file", filename, "error", err)
+			}
+			return assetState.Latitude, assetState.Longitude
+		}
+	}
+
+	// No coordinates found — mark as resolved to avoid re-processing.
+	assetState.GeoResolved = true
+	if err := state.SaveAssetState(albumAbsPath, filename, assetState); err != nil {
+		slog.Warn("failed to save asset state (no coords)", "file", filename, "error", err)
+	}
+	return nil, nil
 }

--- a/backend/internal/index/builder_test.go
+++ b/backend/internal/index/builder_test.go
@@ -5,9 +5,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/perrito666/gollery/backend/internal/config"
 	"github.com/perrito666/gollery/backend/internal/fswalk"
+	"github.com/perrito666/gollery/backend/internal/geo"
+	"github.com/perrito666/gollery/backend/internal/state"
 )
 
 func writeAlbumJSON(t *testing.T, dir, content string) {
@@ -145,6 +148,125 @@ func TestBuildSnapshot_EmptyScan(t *testing.T) {
 	}
 	if snap.GeneratedAt.IsZero() {
 		t.Error("GeneratedAt should be set")
+	}
+}
+
+func float64Ptr(v float64) *float64 { return &v }
+
+func TestResolveCoords_CachedSidecar(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "photo.jpg"))
+
+	as := &state.AssetState{
+		ObjectID:    "ast_test",
+		Latitude:    float64Ptr(48.8566),
+		Longitude:   float64Ptr(2.3522),
+		GeoResolved: true,
+	}
+
+	lat, lon := resolveCoords(dir, "photo.jpg", as, nil)
+	if lat == nil || *lat != 48.8566 {
+		t.Errorf("lat = %v, want 48.8566", lat)
+	}
+	if lon == nil || *lon != 2.3522 {
+		t.Errorf("lon = %v, want 2.3522", lon)
+	}
+}
+
+func TestResolveCoords_GeoResolvedNoCoords(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "photo.jpg"))
+
+	as := &state.AssetState{
+		ObjectID:    "ast_test",
+		GeoResolved: true,
+	}
+
+	lat, lon := resolveCoords(dir, "photo.jpg", as, nil)
+	if lat != nil || lon != nil {
+		t.Errorf("expected nil coords for resolved-no-coords, got (%v, %v)", lat, lon)
+	}
+}
+
+func TestResolveCoords_NoExifMarksResolved(t *testing.T) {
+	dir := t.TempDir()
+	// Write a non-JPEG file (no EXIF possible).
+	writeFile(t, filepath.Join(dir, "photo.jpg"))
+
+	as := &state.AssetState{ObjectID: "ast_test"}
+
+	lat, lon := resolveCoords(dir, "photo.jpg", as, nil)
+	if lat != nil || lon != nil {
+		t.Errorf("expected nil coords, got (%v, %v)", lat, lon)
+	}
+	if !as.GeoResolved {
+		t.Error("GeoResolved should be true after exhausting sources")
+	}
+}
+
+func TestResolveCoords_GPXMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "photo.jpg"))
+
+	// Simulate: EXIF gave us a DateTaken but no GPS.
+	// We can't easily produce a real EXIF file in tests, so test
+	// resolveCoords with GPX points directly by pre-populating
+	// the asset state as if EXIF extraction yielded nothing.
+	// Instead, test the GPX matching function directly.
+	pts := []geo.Trackpoint{
+		{Lat: 40.0, Lon: -74.0, Time: time.Date(2024, 6, 15, 10, 0, 0, 0, time.UTC)},
+		{Lat: 42.0, Lon: -72.0, Time: time.Date(2024, 6, 15, 10, 2, 0, 0, time.UTC)},
+	}
+
+	query := time.Date(2024, 6, 15, 10, 1, 0, 0, time.UTC)
+	lat, lon, ok := geo.MatchNearest(pts, query, 30*time.Second)
+	if !ok {
+		t.Fatal("expected GPX match")
+	}
+	if lat < 40.9 || lat > 41.1 {
+		t.Errorf("lat = %f, want ~41.0", lat)
+	}
+	if lon < -73.1 || lon > -72.9 {
+		t.Errorf("lon = %f, want ~-73.0", lon)
+	}
+}
+
+func TestBuildSnapshot_AlbumFallbackCoords(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "photo.jpg"))
+
+	lat := 48.8566
+	lon := 2.3522
+	scan := &fswalk.ScanResult{
+		Albums: map[string]*fswalk.ScannedAlbum{
+			"": {
+				Path: "",
+				Config: &config.AlbumConfig{
+					Title:     "Paris",
+					Latitude:  &lat,
+					Longitude: &lon,
+				},
+				Assets: []fswalk.ScannedAsset{
+					{Filename: "photo.jpg", ModTime: time.Now(), SizeBytes: 4},
+				},
+			},
+		},
+	}
+
+	snap, err := BuildSnapshot(root, scan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	asset := snap.Albums[""].Assets[0]
+	if asset.Metadata == nil {
+		t.Fatal("expected metadata with album fallback coords")
+	}
+	if asset.Metadata.Latitude == nil || *asset.Metadata.Latitude != 48.8566 {
+		t.Errorf("lat = %v, want 48.8566", asset.Metadata.Latitude)
+	}
+	if asset.Metadata.Longitude == nil || *asset.Metadata.Longitude != 2.3522 {
+		t.Errorf("lon = %v, want 2.3522", asset.Metadata.Longitude)
 	}
 }
 

--- a/backend/internal/state/state.go
+++ b/backend/internal/state/state.go
@@ -77,6 +77,9 @@ type AssetState struct {
 	Description    string              `json:"description,omitempty"`
 	Discussions    []DiscussionBinding `json:"discussions,omitempty"`
 	AccessOverride *AccessOverride     `json:"access_override,omitempty"`
+	Latitude       *float64            `json:"latitude,omitempty"`
+	Longitude      *float64            `json:"longitude,omitempty"`
+	GeoResolved    bool                `json:"geo_resolved,omitempty"`
 }
 
 // AccessOverride stores per-asset ACL overrides in sidecar state.

--- a/frontend/src/core/controllers/asset.js
+++ b/frontend/src/core/controllers/asset.js
@@ -35,6 +35,7 @@ export class AssetController {
         originalURL: this.api.originalURL(asset.id),
         prevAssetId: asset.prev_asset_id || null,
         nextAssetId: asset.next_asset_id || null,
+        geoURI: asset.geo_uri || null,
         discussions,
       };
       this.store.set({ currentView: 'asset', viewModel, loading: false });

--- a/frontend/src/ui-default/views/asset.js
+++ b/frontend/src/ui-default/views/asset.js
@@ -77,6 +77,11 @@ export function render(container, viewModel, ctx) {
   html += '<div class="asset-actions">';
   html += `<a href="${esc(viewModel.originalURL)}" class="btn" target="_blank" rel="noopener">Download original</a>`;
 
+  // Map link
+  if (viewModel.geoURI) {
+    html += ` <a href="${esc(viewModel.geoURI)}" class="btn">View on map</a>`;
+  }
+
   // Mastodon share button
   html += ' <button class="btn asset-share-mastodon" type="button">Share on Mastodon</button>';
 


### PR DESCRIPTION
Resolve asset GPS coordinates from EXIF, GPX tracklogs (with 30s tolerance and interpolation between bracketing points), or album-level fallback. Cache resolved coordinates in sidecar state files and mark assets as geo_resolved to avoid re-processing on subsequent index rebuilds. Expose geo: URI in API responses and render a "View on map" link in the frontend asset view.