### PR TITLE
Replace map link with split button for provider selection

### DIFF
--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -107,16 +107,18 @@ type AssetSummary struct {
 
 // AssetResponse is the JSON representation of an asset.
 type AssetResponse struct {
-	ID          string  `json:"id"`
-	Filename    string  `json:"filename"`
-	Title       string  `json:"title,omitempty"`
-	Description string  `json:"description,omitempty"`
-	AlbumPath   string  `json:"album_path"`
-	AlbumID     string  `json:"album_id"`
-	SizeBytes   int64   `json:"size_bytes"`
-	PrevAssetID *string `json:"prev_asset_id"`
-	NextAssetID *string `json:"next_asset_id"`
-	GeoURI      *string `json:"geo_uri,omitempty"`
+	ID          string   `json:"id"`
+	Filename    string   `json:"filename"`
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	AlbumPath   string   `json:"album_path"`
+	AlbumID     string   `json:"album_id"`
+	SizeBytes   int64    `json:"size_bytes"`
+	PrevAssetID *string  `json:"prev_asset_id"`
+	NextAssetID *string  `json:"next_asset_id"`
+	GeoURI      *string  `json:"geo_uri,omitempty"`
+	Latitude    *float64 `json:"latitude,omitempty"`
+	Longitude   *float64 `json:"longitude,omitempty"`
 }
 
 // MetadataPatchRequest is the JSON body for PATCH /api/v1/assets/{id}/metadata

--- a/backend/internal/api/assets.go
+++ b/backend/internal/api/assets.go
@@ -22,6 +22,17 @@ func formatGeoURI(asset *domain.Asset) *string {
 	return &uri
 }
 
+// assetLatLon returns the latitude or longitude of an asset, or nil.
+func assetLatLon(asset *domain.Asset, isLat bool) *float64 {
+	if asset.Metadata == nil {
+		return nil
+	}
+	if isLat {
+		return asset.Metadata.Latitude
+	}
+	return asset.Metadata.Longitude
+}
+
 // sortAssets sorts a slice of assets in place according to sortOrder.
 // Valid values are "date" (sort by ModTime ascending) and anything else
 // (including "" and "filename") which sorts by filename ascending.
@@ -101,6 +112,8 @@ func (s *Server) handleAssetByID(w http.ResponseWriter, r *http.Request) {
 		PrevAssetID: prev,
 		NextAssetID: next,
 		GeoURI:      formatGeoURI(asset),
+		Latitude:    assetLatLon(asset, true),
+		Longitude:   assetLatLon(asset, false),
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/backend/internal/api/navigation_test.go
+++ b/backend/internal/api/navigation_test.go
@@ -240,6 +240,12 @@ func TestAsset_GeoURI_Present(t *testing.T) {
 	if *resp.GeoURI != "geo:48.856600,2.352200" {
 		t.Errorf("geo_uri = %q, want %q", *resp.GeoURI, "geo:48.856600,2.352200")
 	}
+	if resp.Latitude == nil || *resp.Latitude != 48.8566 {
+		t.Errorf("latitude = %v, want 48.8566", resp.Latitude)
+	}
+	if resp.Longitude == nil || *resp.Longitude != 2.3522 {
+		t.Errorf("longitude = %v, want 2.3522", resp.Longitude)
+	}
 }
 
 func TestAsset_GeoURI_Absent(t *testing.T) {

--- a/frontend/src/core/controllers/asset.js
+++ b/frontend/src/core/controllers/asset.js
@@ -36,6 +36,8 @@ export class AssetController {
         prevAssetId: asset.prev_asset_id || null,
         nextAssetId: asset.next_asset_id || null,
         geoURI: asset.geo_uri || null,
+        latitude: asset.latitude ?? null,
+        longitude: asset.longitude ?? null,
         discussions,
       };
       this.store.set({ currentView: 'asset', viewModel, loading: false });

--- a/frontend/src/ui-default/components/map-button.js
+++ b/frontend/src/ui-default/components/map-button.js
@@ -1,0 +1,148 @@
+/**
+ * Split "View on map" button with provider selection.
+ *
+ * Main click opens the default (or saved) provider.
+ * Dropdown arrow reveals all providers; selecting one opens it
+ * and saves the choice in a cookie.
+ */
+
+import { esc } from '../util/html.js';
+
+const COOKIE_NAME = 'gollery_map_provider';
+const COOKIE_MAX_AGE = 365 * 24 * 60 * 60; // 1 year
+
+/** Map provider definitions. */
+const providers = [
+  {
+    id: 'osm',
+    label: 'OpenStreetMap',
+    url: (lat, lon) =>
+      `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}#map=15/${lat}/${lon}`,
+  },
+  {
+    id: 'google',
+    label: 'Google Maps',
+    url: (lat, lon) =>
+      `https://www.google.com/maps?q=${lat},${lon}`,
+  },
+  {
+    id: 'apple',
+    label: 'Apple Maps',
+    url: (lat, lon) =>
+      `https://maps.apple.com/?ll=${lat},${lon}&q=${lat},${lon}`,
+  },
+  {
+    id: 'geo',
+    label: 'geo: URI',
+    url: (lat, lon) =>
+      `geo:${lat},${lon}`,
+  },
+];
+
+/** Detect a sensible default provider based on platform. */
+function detectDefault() {
+  const ua = navigator.userAgent || '';
+  const platform = navigator.platform || '';
+
+  // iOS — Apple Maps works best
+  if (/iPhone|iPad|iPod/.test(ua)) return 'apple';
+
+  // macOS — Apple Maps handles https links
+  if (/Mac/.test(platform) && !/Android/.test(ua)) return 'apple';
+
+  // Android — geo: URI opens the native chooser
+  if (/Android/.test(ua)) return 'geo';
+
+  // Everything else — OSM is the safe web default
+  return 'osm';
+}
+
+function getSavedProvider() {
+  const match = document.cookie.match(
+    new RegExp('(?:^|; )' + COOKIE_NAME + '=([^;]*)')
+  );
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function saveProvider(id) {
+  document.cookie =
+    COOKIE_NAME + '=' + encodeURIComponent(id) +
+    '; max-age=' + COOKIE_MAX_AGE +
+    '; path=/; SameSite=Lax';
+}
+
+function getProvider() {
+  const saved = getSavedProvider();
+  if (saved && providers.find(p => p.id === saved)) return saved;
+  return detectDefault();
+}
+
+/**
+ * Render the split map button HTML.
+ * @param {number} lat
+ * @param {number} lon
+ * @returns {string}
+ */
+export function renderMapButton(lat, lon) {
+  const current = getProvider();
+  const prov = providers.find(p => p.id === current) || providers[0];
+
+  let html = '<span class="map-split-btn">';
+  html += `<a href="${esc(prov.url(lat, lon))}" class="btn map-btn-main" target="_blank" rel="noopener">${esc(prov.label)}</a>`;
+  html += '<button class="btn map-btn-dropdown" type="button" aria-label="Choose map provider">\u25BE</button>';
+  html += '<div class="map-dropdown-menu" style="display:none">';
+  for (const p of providers) {
+    html += `<a href="${esc(p.url(lat, lon))}" class="map-dropdown-item" data-provider="${esc(p.id)}" target="_blank" rel="noopener">${esc(p.label)}</a>`;
+  }
+  html += '</div>';
+  html += '</span>';
+  return html;
+}
+
+/**
+ * Wire up event listeners for the split map button.
+ * Call after inserting renderMapButton HTML into the DOM.
+ * @param {HTMLElement} container — element containing the split button
+ */
+export function setupMapButton(container) {
+  const wrapper = container.querySelector('.map-split-btn');
+  if (!wrapper) return;
+
+  const dropdownBtn = wrapper.querySelector('.map-btn-dropdown');
+  const menu = wrapper.querySelector('.map-dropdown-menu');
+
+  dropdownBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+  });
+
+  // Close on outside click.
+  const closeMenu = (e) => {
+    if (!wrapper.contains(e.target)) {
+      menu.style.display = 'none';
+    }
+  };
+  document.addEventListener('click', closeMenu);
+
+  // Store a cleanup ref so destroy() can remove the listener.
+  wrapper._closeMenu = closeMenu;
+
+  // On item click: save preference, close menu (link opens via default <a> behavior).
+  for (const item of menu.querySelectorAll('.map-dropdown-item')) {
+    item.addEventListener('click', () => {
+      saveProvider(item.dataset.provider);
+      menu.style.display = 'none';
+    });
+  }
+}
+
+/**
+ * Clean up document-level listeners added by setupMapButton.
+ * @param {HTMLElement} container
+ */
+export function destroyMapButton(container) {
+  const wrapper = container.querySelector('.map-split-btn');
+  if (wrapper && wrapper._closeMenu) {
+    document.removeEventListener('click', wrapper._closeMenu);
+  }
+}

--- a/frontend/src/ui-default/styles/main.css
+++ b/frontend/src/ui-default/styles/main.css
@@ -344,6 +344,53 @@ body {
   background: #5253dd;
 }
 
+/* Map split button */
+.map-split-btn {
+  display: inline-flex;
+  position: relative;
+  vertical-align: middle;
+}
+
+.map-btn-main {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.map-btn-dropdown {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-left: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 0.5rem 0.5rem;
+  min-width: 2rem;
+  font-size: 0.75rem;
+}
+
+.map-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 2px;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 10;
+  min-width: 160px;
+}
+
+.map-dropdown-item {
+  display: block;
+  padding: 0.5rem 0.75rem;
+  color: #333;
+  text-decoration: none;
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.map-dropdown-item:hover {
+  background: #f0f0f0;
+}
+
 /* Loading state */
 .loading {
   text-align: center;

--- a/frontend/src/ui-default/views/asset.js
+++ b/frontend/src/ui-default/views/asset.js
@@ -8,6 +8,7 @@
 import { esc } from '../util/html.js';
 import { renderNav } from '../util/nav.js';
 import { renderDiscussionLinks } from '../components/discussion-links.js';
+import { renderMapButton, setupMapButton, destroyMapButton } from '../components/map-button.js';
 
 export function render(container, viewModel, ctx) {
   if (!viewModel) {
@@ -77,9 +78,9 @@ export function render(container, viewModel, ctx) {
   html += '<div class="asset-actions">';
   html += `<a href="${esc(viewModel.originalURL)}" class="btn" target="_blank" rel="noopener">Download original</a>`;
 
-  // Map link
-  if (viewModel.geoURI) {
-    html += ` <a href="${esc(viewModel.geoURI)}" class="btn">View on map</a>`;
+  // Map link (split button with provider dropdown)
+  if (viewModel.latitude != null && viewModel.longitude != null) {
+    html += ' ' + renderMapButton(viewModel.latitude, viewModel.longitude);
   }
 
   // Mastodon share button
@@ -111,6 +112,9 @@ export function render(container, viewModel, ctx) {
 
   container.innerHTML = html;
   nav.setup(container);
+
+  // Wire up map split button
+  setupMapButton(container);
 
   // Render discussion links
   const discEl = container.querySelector('.asset-discussions');
@@ -235,4 +239,6 @@ export function render(container, viewModel, ctx) {
   }
 }
 
-export function destroy() {}
+export function destroy(container) {
+  if (container) destroyMapButton(container);
+}


### PR DESCRIPTION
The main button opens the platform-appropriate default (Apple Maps on macOS/iOS, geo: URI on Android, OpenStreetMap elsewhere). The dropdown arrow reveals all providers (OSM, Google, Apple, geo:) and saves the user's choice in a cookie. The API now also returns raw latitude and longitude so the frontend can construct provider-specific URLs.