### PR TITLE
Add TCX track file support for photo geotagging

### DIFF
--- a/backend/internal/fswalk/fswalk.go
+++ b/backend/internal/fswalk/fswalk.go
@@ -80,8 +80,10 @@ type ScannedAlbum struct {
 	// ChildPaths lists relative paths of direct child albums.
 	ChildPaths []string
 
-	// GPXFiles lists absolute paths to .gpx files found in this directory.
-	GPXFiles []string
+	// TrackFiles lists absolute paths to GPS track logs (.gpx and .tcx)
+	// found in this directory. Both formats yield timestamped trackpoints
+	// used for photo geotagging.
+	TrackFiles []string
 }
 
 // ScanResult holds the output of a content tree scan.
@@ -179,17 +181,17 @@ func Scan(contentRoot string) (*ScanResult, error) {
 
 		resolved[relPath] = cfg
 
-		// Scan for image assets and GPX files in this directory.
-		assets, gpxFiles, scanErr := scanDir(absPath)
+		// Scan for image assets and GPS track files in this directory.
+		assets, trackFiles, scanErr := scanDir(absPath)
 		if scanErr != nil {
 			result.Errors = append(result.Errors, ScanError{Path: relPath, Err: scanErr})
 		}
 
 		album := &ScannedAlbum{
-			Path:     relPath,
-			Config:   cfg,
-			Assets:   assets,
-			GPXFiles: gpxFiles,
+			Path:       relPath,
+			Config:     cfg,
+			Assets:     assets,
+			TrackFiles: trackFiles,
 		}
 		result.Albums[relPath] = album
 
@@ -213,7 +215,8 @@ func Scan(contentRoot string) (*ScanResult, error) {
 	return result, nil
 }
 
-// scanDir reads a directory and returns recognized image files and GPX file paths.
+// scanDir reads a directory and returns recognized image files along with
+// absolute paths to GPS track logs (.gpx and .tcx).
 func scanDir(dirPath string) ([]ScannedAsset, []string, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
@@ -221,14 +224,14 @@ func scanDir(dirPath string) ([]ScannedAsset, []string, error) {
 	}
 
 	var assets []ScannedAsset
-	var gpxFiles []string
+	var trackFiles []string
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
 		ext := strings.ToLower(filepath.Ext(e.Name()))
-		if ext == ".gpx" {
-			gpxFiles = append(gpxFiles, filepath.Join(dirPath, e.Name()))
+		if ext == ".gpx" || ext == ".tcx" {
+			trackFiles = append(trackFiles, filepath.Join(dirPath, e.Name()))
 			continue
 		}
 		if !ImageExtensions[ext] {
@@ -244,5 +247,5 @@ func scanDir(dirPath string) ([]ScannedAsset, []string, error) {
 			SizeBytes: info.Size(),
 		})
 	}
-	return assets, gpxFiles, nil
+	return assets, trackFiles, nil
 }

--- a/backend/internal/fswalk/fswalk_test.go
+++ b/backend/internal/fswalk/fswalk_test.go
@@ -216,12 +216,14 @@ func TestScan_ChildPaths(t *testing.T) {
 	}
 }
 
-func TestScan_GPXFilesDiscovered(t *testing.T) {
+func TestScan_TrackFilesDiscovered(t *testing.T) {
 	root := t.TempDir()
 	writeAlbumJSON(t, root, `{"title": "Root"}`)
 	writeFile(t, filepath.Join(root, "photo.jpg"))
 	writeFile(t, filepath.Join(root, "track.gpx"))
 	writeFile(t, filepath.Join(root, "route.gpx"))
+	writeFile(t, filepath.Join(root, "workout.tcx"))
+	writeFile(t, filepath.Join(root, "ride.TCX"))
 
 	result, err := Scan(root)
 	if err != nil {
@@ -232,13 +234,12 @@ func TestScan_GPXFilesDiscovered(t *testing.T) {
 	if len(album.Assets) != 1 {
 		t.Errorf("expected 1 asset, got %d", len(album.Assets))
 	}
-	if len(album.GPXFiles) != 2 {
-		t.Errorf("expected 2 GPX files, got %d: %v", len(album.GPXFiles), album.GPXFiles)
+	if len(album.TrackFiles) != 4 {
+		t.Errorf("expected 4 track files, got %d: %v", len(album.TrackFiles), album.TrackFiles)
 	}
-	// GPX files should be absolute paths.
-	for _, f := range album.GPXFiles {
+	for _, f := range album.TrackFiles {
 		if !filepath.IsAbs(f) {
-			t.Errorf("GPX path should be absolute: %s", f)
+			t.Errorf("track path should be absolute: %s", f)
 		}
 	}
 }

--- a/backend/internal/geo/tcx.go
+++ b/backend/internal/geo/tcx.go
@@ -1,0 +1,153 @@
+package geo
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// tcxFile represents the top-level Training Center XML structure.
+// The schema places trackpoints under Activities > Activity > Lap > Track,
+// with an alternative Courses > Course > Track path used by some exporters.
+type tcxFile struct {
+	XMLName    xml.Name     `xml:"TrainingCenterDatabase"`
+	Activities tcxActivities `xml:"Activities"`
+	Courses    tcxCourses    `xml:"Courses"`
+}
+
+type tcxActivities struct {
+	Activities []tcxActivity `xml:"Activity"`
+}
+
+type tcxActivity struct {
+	Laps []tcxLap `xml:"Lap"`
+}
+
+type tcxLap struct {
+	Tracks []tcxTrack `xml:"Track"`
+}
+
+type tcxCourses struct {
+	Courses []tcxCourse `xml:"Course"`
+}
+
+type tcxCourse struct {
+	Tracks []tcxTrack `xml:"Track"`
+}
+
+type tcxTrack struct {
+	Points []tcxTrackpoint `xml:"Trackpoint"`
+}
+
+type tcxTrackpoint struct {
+	Time     string       `xml:"Time"`
+	Position *tcxPosition `xml:"Position"`
+}
+
+type tcxPosition struct {
+	Lat float64 `xml:"LatitudeDegrees"`
+	Lon float64 `xml:"LongitudeDegrees"`
+}
+
+// ParseTCXFiles reads one or more TCX (Training Center XML) files and returns
+// all trackpoints sorted by time. Points without a parseable timestamp or
+// without a <Position> element (e.g. indoor treadmill segments or GPS drop-outs)
+// are silently skipped.
+func ParseTCXFiles(paths []string) ([]Trackpoint, error) {
+	var all []Trackpoint
+	for _, path := range paths {
+		pts, err := parseOneTCX(path)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+		all = append(all, pts...)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Time.Before(all[j].Time)
+	})
+	return all, nil
+}
+
+func parseOneTCX(path string) ([]Trackpoint, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var tcx tcxFile
+	if err := xml.Unmarshal(data, &tcx); err != nil {
+		return nil, err
+	}
+
+	var pts []Trackpoint
+	appendTracks := func(tracks []tcxTrack) {
+		for _, tr := range tracks {
+			for _, pt := range tr.Points {
+				if pt.Position == nil {
+					continue
+				}
+				t, err := time.Parse(time.RFC3339, pt.Time)
+				if err != nil {
+					t, err = time.Parse(time.RFC3339Nano, pt.Time)
+					if err != nil {
+						continue
+					}
+				}
+				pts = append(pts, Trackpoint{
+					Lat:  pt.Position.Lat,
+					Lon:  pt.Position.Lon,
+					Time: t,
+				})
+			}
+		}
+	}
+	for _, act := range tcx.Activities.Activities {
+		for _, lap := range act.Laps {
+			appendTracks(lap.Tracks)
+		}
+	}
+	for _, course := range tcx.Courses.Courses {
+		appendTracks(course.Tracks)
+	}
+	return pts, nil
+}
+
+// ParseTrackFiles parses a mixed set of GPX and TCX track files, dispatched
+// by lowercase file extension, and returns the merged trackpoints sorted by
+// time. Unknown extensions return an error so misconfiguration is not silent.
+func ParseTrackFiles(paths []string) ([]Trackpoint, error) {
+	var gpxPaths, tcxPaths []string
+	for _, p := range paths {
+		switch strings.ToLower(filepath.Ext(p)) {
+		case ".gpx":
+			gpxPaths = append(gpxPaths, p)
+		case ".tcx":
+			tcxPaths = append(tcxPaths, p)
+		default:
+			return nil, fmt.Errorf("unsupported track file extension: %s", p)
+		}
+	}
+
+	var all []Trackpoint
+	if len(gpxPaths) > 0 {
+		pts, err := ParseGPXFiles(gpxPaths)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, pts...)
+	}
+	if len(tcxPaths) > 0 {
+		pts, err := ParseTCXFiles(tcxPaths)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, pts...)
+	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Time.Before(all[j].Time)
+	})
+	return all, nil
+}

--- a/backend/internal/geo/tcx_test.go
+++ b/backend/internal/geo/tcx_test.go
@@ -1,0 +1,177 @@
+package geo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleTCX = `<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
+  <Activities>
+    <Activity Sport="Biking">
+      <Lap StartTime="2024-06-15T10:00:00Z">
+        <Track>
+          <Trackpoint>
+            <Time>2024-06-15T10:00:00Z</Time>
+            <Position>
+              <LatitudeDegrees>48.8566</LatitudeDegrees>
+              <LongitudeDegrees>2.3522</LongitudeDegrees>
+            </Position>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2024-06-15T10:01:00Z</Time>
+            <Position>
+              <LatitudeDegrees>48.8570</LatitudeDegrees>
+              <LongitudeDegrees>2.3530</LongitudeDegrees>
+            </Position>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2024-06-15T10:02:00Z</Time>
+          </Trackpoint>
+          <Trackpoint>
+            <Time>2024-06-15T10:03:00Z</Time>
+            <Position>
+              <LatitudeDegrees>48.8580</LatitudeDegrees>
+              <LongitudeDegrees>2.3540</LongitudeDegrees>
+            </Position>
+          </Trackpoint>
+        </Track>
+      </Lap>
+    </Activity>
+  </Activities>
+</TrainingCenterDatabase>`
+
+const courseTCX = `<?xml version="1.0" encoding="UTF-8"?>
+<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2">
+  <Courses>
+    <Course>
+      <Track>
+        <Trackpoint>
+          <Time>2024-06-15T09:00:00Z</Time>
+          <Position>
+            <LatitudeDegrees>40.7128</LatitudeDegrees>
+            <LongitudeDegrees>-74.0060</LongitudeDegrees>
+          </Position>
+        </Trackpoint>
+      </Track>
+    </Course>
+  </Courses>
+</TrainingCenterDatabase>`
+
+func writeFileGeo(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestParseTCXFiles_Basic(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFileGeo(t, dir, "workout.tcx", sampleTCX)
+
+	pts, err := ParseTCXFiles([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One trackpoint has no Position — should be skipped.
+	if len(pts) != 3 {
+		t.Fatalf("got %d points, want 3", len(pts))
+	}
+	if pts[0].Lat != 48.8566 || pts[0].Lon != 2.3522 {
+		t.Errorf("first point = (%f, %f), want (48.8566, 2.3522)", pts[0].Lat, pts[0].Lon)
+	}
+}
+
+func TestParseTCXFiles_CoursesSection(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFileGeo(t, dir, "course.tcx", courseTCX)
+
+	pts, err := ParseTCXFiles([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pts) != 1 {
+		t.Fatalf("got %d points, want 1", len(pts))
+	}
+	if pts[0].Lat != 40.7128 {
+		t.Errorf("lat = %f, want 40.7128", pts[0].Lat)
+	}
+}
+
+func TestParseTCXFiles_Multiple_SortedByTime(t *testing.T) {
+	dir := t.TempDir()
+	p1 := writeFileGeo(t, dir, "a.tcx", sampleTCX)
+	p2 := writeFileGeo(t, dir, "b.tcx", courseTCX)
+
+	pts, err := ParseTCXFiles([]string{p1, p2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pts) != 4 {
+		t.Fatalf("got %d points, want 4", len(pts))
+	}
+	// courseTCX point at 09:00 should sort ahead of the 10:00 activity.
+	if pts[0].Lat != 40.7128 {
+		t.Errorf("first point lat = %f, want 40.7128 (earliest)", pts[0].Lat)
+	}
+}
+
+func TestParseTCXFiles_InvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFileGeo(t, dir, "bad.tcx", "not xml at all {{{")
+
+	_, err := ParseTCXFiles([]string{path})
+	if err == nil {
+		t.Error("expected error for invalid XML")
+	}
+}
+
+func TestParseTCXFiles_MissingFile(t *testing.T) {
+	_, err := ParseTCXFiles([]string{"/nonexistent/workout.tcx"})
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestParseTrackFiles_MixedGPXAndTCX(t *testing.T) {
+	dir := t.TempDir()
+	gpxPath := writeFileGeo(t, dir, "track.gpx", sampleGPX)
+	tcxPath := writeFileGeo(t, dir, "course.tcx", courseTCX)
+
+	pts, err := ParseTrackFiles([]string{gpxPath, tcxPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 3 from GPX + 1 from TCX course.
+	if len(pts) != 4 {
+		t.Fatalf("got %d points, want 4", len(pts))
+	}
+	// Merged output must be sorted by time; TCX course point at 09:00
+	// should precede all GPX points (10:00+).
+	if pts[0].Lat != 40.7128 {
+		t.Errorf("first point lat = %f, want 40.7128 (earliest across formats)", pts[0].Lat)
+	}
+}
+
+func TestParseTrackFiles_UnknownExtension(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFileGeo(t, dir, "log.kml", "<kml/>")
+
+	_, err := ParseTrackFiles([]string{path})
+	if err == nil {
+		t.Error("expected error for unsupported extension")
+	}
+}
+
+func TestParseTrackFiles_EmptyInput(t *testing.T) {
+	pts, err := ParseTrackFiles(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pts) != 0 {
+		t.Errorf("expected 0 points, got %d", len(pts))
+	}
+}

--- a/backend/internal/index/builder.go
+++ b/backend/internal/index/builder.go
@@ -48,7 +48,7 @@ import (
 	"github.com/perrito666/gollery/backend/internal/state"
 )
 
-const gpxTolerance = 30 * time.Second
+const trackTolerance = 30 * time.Second
 
 // BuildSnapshot combines scanner output with sidecar state to produce
 // a point-in-time Snapshot with stable IDs and album hierarchy.
@@ -83,14 +83,14 @@ func BuildSnapshot(contentRoot string, scan *fswalk.ScanResult) (*domain.Snapsho
 			}
 		}
 
-		// Parse GPX files for this album (once, shared across assets).
-		var gpxPoints []geo.Trackpoint
-		if len(scanned.GPXFiles) > 0 {
-			pts, err := geo.ParseGPXFiles(scanned.GPXFiles)
+		// Parse GPS track files (GPX + TCX) for this album (once, shared across assets).
+		var trackPoints []geo.Trackpoint
+		if len(scanned.TrackFiles) > 0 {
+			pts, err := geo.ParseTrackFiles(scanned.TrackFiles)
 			if err != nil {
-				slog.Warn("failed to parse GPX files", "album", relPath, "error", err)
+				slog.Warn("failed to parse GPS track files", "album", relPath, "error", err)
 			} else {
-				gpxPoints = pts
+				trackPoints = pts
 			}
 		}
 
@@ -127,7 +127,7 @@ func BuildSnapshot(contentRoot string, scan *fswalk.ScanResult) (*domain.Snapsho
 
 			// Resolve GPS coordinates.
 			resolvedLat, resolvedLon := resolveCoords(
-				absPath, sa.Filename, assetState, gpxPoints,
+				absPath, sa.Filename, assetState, trackPoints,
 			)
 
 			if resolvedLat != nil && resolvedLon != nil {
@@ -163,13 +163,13 @@ func BuildSnapshot(contentRoot string, scan *fswalk.ScanResult) (*domain.Snapsho
 }
 
 // resolveCoords attempts to resolve GPS coordinates for an asset.
-// It checks: cached sidecar → EXIF → GPX matching.
+// It checks: cached sidecar → EXIF → track-log matching (GPX/TCX).
 // If coordinates are found (or all sources exhausted), it persists
 // the result to the sidecar and sets GeoResolved to avoid re-processing.
 func resolveCoords(
 	albumAbsPath, filename string,
 	assetState *state.AssetState,
-	gpxPoints []geo.Trackpoint,
+	trackPoints []geo.Trackpoint,
 ) (lat, lon *float64) {
 	// Already resolved — use cached result (may be nil if no coords found).
 	if assetState.GeoResolved {
@@ -193,15 +193,15 @@ func resolveCoords(
 		return assetState.Latitude, assetState.Longitude
 	}
 
-	// Try GPX matching (requires DateTaken from EXIF).
-	if exifMeta != nil && exifMeta.DateTaken != nil && len(gpxPoints) > 0 {
-		glat, glon, ok := geo.MatchNearest(gpxPoints, *exifMeta.DateTaken, gpxTolerance)
+	// Try track-log matching (GPX/TCX; requires DateTaken from EXIF).
+	if exifMeta != nil && exifMeta.DateTaken != nil && len(trackPoints) > 0 {
+		glat, glon, ok := geo.MatchNearest(trackPoints, *exifMeta.DateTaken, trackTolerance)
 		if ok {
 			assetState.Latitude = &glat
 			assetState.Longitude = &glon
 			assetState.GeoResolved = true
 			if err := state.SaveAssetState(albumAbsPath, filename, assetState); err != nil {
-				slog.Warn("failed to save asset state with GPX coords", "file", filename, "error", err)
+				slog.Warn("failed to save asset state with track coords", "file", filename, "error", err)
 			}
 			return assetState.Latitude, assetState.Longitude
 		}


### PR DESCRIPTION
Photos can now be geotagged from Garmin TCX (Training Center XML) files in addition to GPX. Both formats are discovered in album directories and merged into a single sorted trackpoint stream for EXIF timestamp matching.

Introduces geo.ParseTCXFiles (handles both Activities and Courses layouts, skips trackpoints without a Position) and geo.ParseTrackFiles as a unified dispatcher over .gpx and .tcx. Renames fswalk.ScannedAlbum.GPXFiles to TrackFiles to reflect the broader scope.