### PR TITLE
Date taken sort

### DIFF
--- a/backend/internal/api/assets.go
+++ b/backend/internal/api/assets.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/perrito666/gollery/backend/internal/derive"
 	"github.com/perrito666/gollery/backend/internal/domain"
@@ -34,19 +35,41 @@ func assetLatLon(asset *domain.Asset, isLat bool) *float64 {
 }
 
 // sortAssets sorts a slice of assets in place according to sortOrder.
-// Valid values are "date" (sort by ModTime ascending) and anything else
-// (including "" and "filename") which sorts by filename ascending.
+// Valid values:
+//   - "date":       ModTime ascending
+//   - "date_taken": EXIF DateTaken ascending, with ModTime as fallback for
+//                   assets that lack an EXIF timestamp; ties break by filename
+//   - anything else (including "" and "filename"): filename ascending
 func sortAssets(assets []domain.Asset, sortOrder string) {
 	switch sortOrder {
 	case "date":
 		sort.Slice(assets, func(i, j int) bool {
 			return assets[i].ModTime.Before(assets[j].ModTime)
 		})
+	case "date_taken":
+		sort.Slice(assets, func(i, j int) bool {
+			ti := assetSortTime(&assets[i])
+			tj := assetSortTime(&assets[j])
+			if ti.Equal(tj) {
+				return assets[i].Filename < assets[j].Filename
+			}
+			return ti.Before(tj)
+		})
 	default:
 		sort.Slice(assets, func(i, j int) bool {
 			return assets[i].Filename < assets[j].Filename
 		})
 	}
+}
+
+// assetSortTime returns the timestamp used to order an asset under the
+// "date_taken" sort order: EXIF DateTaken when available, otherwise the
+// filesystem ModTime.
+func assetSortTime(a *domain.Asset) time.Time {
+	if a.Metadata != nil && a.Metadata.DateTaken != nil {
+		return *a.Metadata.DateTaken
+	}
+	return a.ModTime
 }
 
 // findAdjacentAssets returns the previous and next asset IDs relative to

--- a/backend/internal/api/assets_sort_test.go
+++ b/backend/internal/api/assets_sort_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/perrito666/gollery/backend/internal/domain"
+)
+
+func TestSortAssets_Filename(t *testing.T) {
+	assets := []domain.Asset{
+		{ID: "b", Filename: "b.jpg"},
+		{ID: "a", Filename: "a.jpg"},
+		{ID: "c", Filename: "c.jpg"},
+	}
+	sortAssets(assets, "filename")
+	want := []string{"a", "b", "c"}
+	for i, w := range want {
+		if assets[i].ID != w {
+			t.Errorf("[%d] id = %q, want %q", i, assets[i].ID, w)
+		}
+	}
+}
+
+func TestSortAssets_Date_UsesModTime(t *testing.T) {
+	early := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	mid := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	late := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
+	assets := []domain.Asset{
+		{ID: "mid", Filename: "b.jpg", ModTime: mid},
+		{ID: "late", Filename: "a.jpg", ModTime: late},
+		{ID: "early", Filename: "c.jpg", ModTime: early},
+	}
+	sortAssets(assets, "date")
+	want := []string{"early", "mid", "late"}
+	for i, w := range want {
+		if assets[i].ID != w {
+			t.Errorf("[%d] id = %q, want %q", i, assets[i].ID, w)
+		}
+	}
+}
+
+func TestSortAssets_DateTaken_PrefersEXIFOverModTime(t *testing.T) {
+	// Two assets with inverted ModTime vs EXIF DateTaken order: sort
+	// must follow EXIF DateTaken, ignoring ModTime.
+	shotEarly := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	shotLate := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	mtimeSwapped := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	assets := []domain.Asset{
+		{
+			ID:       "shot-late",
+			Filename: "a.jpg",
+			ModTime:  time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			Metadata: &domain.ImageMetadata{DateTaken: &shotLate},
+		},
+		{
+			ID:       "shot-early",
+			Filename: "b.jpg",
+			ModTime:  mtimeSwapped, // mtime later than shot-late's shot time
+			Metadata: &domain.ImageMetadata{DateTaken: &shotEarly},
+		},
+	}
+	sortAssets(assets, "date_taken")
+	if assets[0].ID != "shot-early" {
+		t.Fatalf("expected shot-early first, got %q", assets[0].ID)
+	}
+	if assets[1].ID != "shot-late" {
+		t.Fatalf("expected shot-late second, got %q", assets[1].ID)
+	}
+}
+
+func TestSortAssets_DateTaken_FallsBackToModTime(t *testing.T) {
+	// One asset has EXIF DateTaken, one does not. The one without falls
+	// back to its ModTime and mixes into the ordering correctly.
+	shot := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	earlyMod := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	lateMod := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
+
+	assets := []domain.Asset{
+		{ID: "with-exif", Filename: "b.jpg", ModTime: lateMod,
+			Metadata: &domain.ImageMetadata{DateTaken: &shot}},
+		{ID: "no-exif-early", Filename: "a.jpg", ModTime: earlyMod},
+		{ID: "no-exif-late", Filename: "c.jpg", ModTime: lateMod},
+	}
+	sortAssets(assets, "date_taken")
+	want := []string{"no-exif-early", "with-exif", "no-exif-late"}
+	for i, w := range want {
+		if assets[i].ID != w {
+			t.Errorf("[%d] id = %q, want %q", i, assets[i].ID, w)
+		}
+	}
+}
+
+func TestSortAssets_DateTaken_TieBreakerByFilename(t *testing.T) {
+	// Same DateTaken should sort by filename for determinism.
+	shot := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	assets := []domain.Asset{
+		{ID: "b", Filename: "b.jpg", Metadata: &domain.ImageMetadata{DateTaken: &shot}},
+		{ID: "a", Filename: "a.jpg", Metadata: &domain.ImageMetadata{DateTaken: &shot}},
+	}
+	sortAssets(assets, "date_taken")
+	if assets[0].ID != "a" || assets[1].ID != "b" {
+		t.Errorf("tie-broken order = [%s,%s], want [a,b]", assets[0].ID, assets[1].ID)
+	}
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -99,7 +99,12 @@ type AlbumConfig struct {
 	Derivatives *DerivativesConfig `json:"derivatives,omitempty"`
 
 	// SortOrder controls how assets are ordered when listing an album.
-	// Valid values: "filename" (default), "date" (sort by file modification time).
+	// Valid values:
+	//   - "filename" (default): case-sensitive filename ascending
+	//   - "date":               file modification time ascending
+	//   - "date_taken":         EXIF DateTimeOriginal ascending, with
+	//                          ModTime as fallback for assets that lack
+	//                          an EXIF timestamp
 	SortOrder string `json:"sort_order,omitempty"`
 
 	// Latitude is the album-level default latitude for assets without
@@ -149,9 +154,10 @@ var ValidAccessModes = map[string]bool{
 
 // ValidSortOrders lists the allowed values for AlbumConfig.SortOrder.
 var ValidSortOrders = map[string]bool{
-	"":         true, // empty means default (filename)
-	"filename": true,
-	"date":     true,
+	"":           true, // empty means default (filename)
+	"filename":   true,
+	"date":       true,
+	"date_taken": true,
 }
 
 // LoadAlbumConfig reads and parses an album.json file.

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -93,6 +93,10 @@ func TestAlbumConfigValidate(t *testing.T) {
 			cfg:  AlbumConfig{SortOrder: "date"},
 		},
 		{
+			name: "valid sort_order date_taken",
+			cfg:  AlbumConfig{SortOrder: "date_taken"},
+		},
+		{
 			name: "valid sort_order empty",
 			cfg:  AlbumConfig{SortOrder: ""},
 		},

--- a/backend/internal/index/builder.go
+++ b/backend/internal/index/builder.go
@@ -125,22 +125,29 @@ func BuildSnapshot(contentRoot string, scan *fswalk.ScanResult) (*domain.Snapsho
 				}
 			}
 
-			// Resolve GPS coordinates.
+			// Resolve GPS coordinates and cached EXIF metadata (DateTaken).
 			resolvedLat, resolvedLon := resolveCoords(
 				absPath, sa.Filename, assetState, gpxPoints,
 			)
 
-			if resolvedLat != nil && resolvedLon != nil {
+			switch {
+			case resolvedLat != nil && resolvedLon != nil:
 				asset.Metadata = &domain.ImageMetadata{
 					Latitude:  resolvedLat,
 					Longitude: resolvedLon,
+					DateTaken: assetState.DateTaken,
 				}
-			} else if albumLat != nil && albumLon != nil {
+			case albumLat != nil && albumLon != nil:
 				// Album-level fallback (not persisted to asset sidecar).
 				lat, lon := *albumLat, *albumLon
 				asset.Metadata = &domain.ImageMetadata{
 					Latitude:  &lat,
 					Longitude: &lon,
+					DateTaken: assetState.DateTaken,
+				}
+			case assetState.DateTaken != nil:
+				asset.Metadata = &domain.ImageMetadata{
+					DateTaken: assetState.DateTaken,
 				}
 			}
 
@@ -164,23 +171,40 @@ func BuildSnapshot(contentRoot string, scan *fswalk.ScanResult) (*domain.Snapsho
 
 // resolveCoords attempts to resolve GPS coordinates for an asset.
 // It checks: cached sidecar → EXIF → GPX matching.
-// If coordinates are found (or all sources exhausted), it persists
-// the result to the sidecar and sets GeoResolved to avoid re-processing.
+// It also caches the EXIF DateTaken when it reads the file, so the
+// "date_taken" sort order does not have to re-open images on later builds.
+// If either coords or metadata still need resolving, EXIF is read once;
+// results are persisted with GeoResolved and MetaResolved set true.
 func resolveCoords(
 	albumAbsPath, filename string,
 	assetState *state.AssetState,
 	gpxPoints []geo.Trackpoint,
 ) (lat, lon *float64) {
-	// Already resolved — use cached result (may be nil if no coords found).
-	if assetState.GeoResolved {
+	// Both resolved already — use cached values (may be nil).
+	if assetState.GeoResolved && assetState.MetaResolved {
 		return assetState.Latitude, assetState.Longitude
 	}
 
-	// Try EXIF extraction.
+	// Try EXIF extraction. This yields both coords (if present) and DateTaken.
 	filePath := filepath.Join(albumAbsPath, filename)
 	exifMeta, err := meta.Extract(filePath)
 	if err != nil {
 		slog.Warn("EXIF extraction failed", "file", filename, "error", err)
+	}
+
+	// Cache DateTaken regardless of whether coords resolve.
+	if exifMeta != nil && exifMeta.DateTaken != nil {
+		assetState.DateTaken = exifMeta.DateTaken
+	}
+	assetState.MetaResolved = true
+
+	// If coords were already cached earlier, don't recompute — just persist
+	// the newly resolved metadata and return the existing coords.
+	if assetState.GeoResolved {
+		if err := state.SaveAssetState(albumAbsPath, filename, assetState); err != nil {
+			slog.Warn("failed to save asset state with EXIF metadata", "file", filename, "error", err)
+		}
+		return assetState.Latitude, assetState.Longitude
 	}
 
 	if exifMeta != nil && exifMeta.Latitude != nil && exifMeta.Longitude != nil {

--- a/backend/internal/index/builder_test.go
+++ b/backend/internal/index/builder_test.go
@@ -188,6 +188,48 @@ func TestResolveCoords_GeoResolvedNoCoords(t *testing.T) {
 	}
 }
 
+func TestResolveCoords_CachedDateTakenSurfaces(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "photo.jpg"))
+
+	shot := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	as := &state.AssetState{
+		ObjectID:     "ast_test",
+		GeoResolved:  true,
+		MetaResolved: true,
+		DateTaken:    &shot,
+	}
+
+	// Both flags true — should not touch the file. DateTaken must survive.
+	resolveCoords(dir, "photo.jpg", as, nil)
+	if as.DateTaken == nil || !as.DateTaken.Equal(shot) {
+		t.Errorf("cached DateTaken = %v, want %v", as.DateTaken, shot)
+	}
+}
+
+func TestResolveCoords_MetaResolutionOnUpgrade(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "photo.jpg"))
+
+	// Simulate an install that predates DateTaken caching: GeoResolved
+	// is already set, MetaResolved is false. resolveCoords must attempt
+	// EXIF once, mark MetaResolved, and preserve existing coords.
+	as := &state.AssetState{
+		ObjectID:    "ast_test",
+		GeoResolved: true,
+		Latitude:    float64Ptr(48.8566),
+		Longitude:   float64Ptr(2.3522),
+	}
+
+	lat, lon := resolveCoords(dir, "photo.jpg", as, nil)
+	if lat == nil || *lat != 48.8566 || lon == nil || *lon != 2.3522 {
+		t.Errorf("coords lost during meta resolve: (%v, %v)", lat, lon)
+	}
+	if !as.MetaResolved {
+		t.Error("MetaResolved should be true after upgrade path")
+	}
+}
+
 func TestResolveCoords_NoExifMarksResolved(t *testing.T) {
 	dir := t.TempDir()
 	// Write a non-JPEG file (no EXIF possible).
@@ -201,6 +243,9 @@ func TestResolveCoords_NoExifMarksResolved(t *testing.T) {
 	}
 	if !as.GeoResolved {
 		t.Error("GeoResolved should be true after exhausting sources")
+	}
+	if !as.MetaResolved {
+		t.Error("MetaResolved should be true after exhausting sources")
 	}
 }
 

--- a/backend/internal/state/state.go
+++ b/backend/internal/state/state.go
@@ -53,6 +53,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 const (
@@ -80,6 +81,13 @@ type AssetState struct {
 	Latitude       *float64            `json:"latitude,omitempty"`
 	Longitude      *float64            `json:"longitude,omitempty"`
 	GeoResolved    bool                `json:"geo_resolved,omitempty"`
+	// DateTaken caches the EXIF capture timestamp so the "date_taken"
+	// sort order does not have to re-read image files on every re-index.
+	DateTaken *time.Time `json:"date_taken,omitempty"`
+	// MetaResolved marks that non-geo EXIF metadata (currently DateTaken)
+	// has been extracted. Kept separate from GeoResolved so that upgrading
+	// installs re-extract EXIF once to populate DateTaken.
+	MetaResolved bool `json:"meta_resolved,omitempty"`
 }
 
 // AccessOverride stores per-asset ACL overrides in sidecar state.


### PR DESCRIPTION
Albums can now set "sort_order": "date_taken" in album.json to order
assets by EXIF DateTimeOriginal ascending, with ModTime as a fallback
for assets that lack an EXIF timestamp and filename as a tie-breaker.

EXIF DateTaken is cached in the .gallery/assets sidecar alongside the
existing coord cache, so re-index does not have to re-open image files.
A new MetaResolved flag on AssetState triggers a one-time EXIF re-read
on installs that predate this change, preserving existing coord state.