### PR TITLE
Load full albums via infinite scroll

### DIFF
--- a/frontend/src/core/api/client.js
+++ b/frontend/src/core/api/client.js
@@ -15,8 +15,21 @@ export class ApiClient {
     return this._get('/albums/root');
   }
 
-  async getAlbum(id) {
-    return this._get(`/albums/${encodeURIComponent(id)}`);
+  /**
+   * Fetch an album by ID. Optional pagination via {offset, limit}.
+   * The backend caps limit at 500 and defaults to 100 when unspecified.
+   */
+  async getAlbum(id, opts = {}) {
+    const params = new URLSearchParams();
+    if (Number.isFinite(opts.offset) && opts.offset > 0) {
+      params.set('offset', String(opts.offset));
+    }
+    if (Number.isFinite(opts.limit) && opts.limit > 0) {
+      params.set('limit', String(opts.limit));
+    }
+    const query = params.toString();
+    const suffix = query ? `?${query}` : '';
+    return this._get(`/albums/${encodeURIComponent(id)}${suffix}`);
   }
 
   async getAsset(id) {

--- a/frontend/src/core/controllers/album.js
+++ b/frontend/src/core/controllers/album.js
@@ -37,20 +37,40 @@ export class AlbumController {
   }
 
   _toViewModel(album) {
+    const assets = (album.assets || []).map(a => this._assetToViewModel(a));
     return {
       id: album.id,
       title: album.title,
       description: album.description || '',
       path: album.path,
       children: (album.children || []).map(c => ({ id: c.id, path: c.path, title: c.title })),
-      assets: (album.assets || []).map(a => ({
-        id: a.id,
-        filename: a.filename,
-        title: a.title || '',
-        description: a.description || '',
-        thumbnailURL: this.api.thumbnailURL(a.id),
-      })),
+      assets,
+      // totalAssets is the true count after ACL filtering (see backend
+      // AlbumResponse.total_assets). The view uses it to know when to
+      // stop lazily loading more pages.
+      totalAssets: typeof album.total_assets === 'number' ? album.total_assets : assets.length,
     };
   }
 
+  _assetToViewModel(a) {
+    return {
+      id: a.id,
+      filename: a.filename,
+      title: a.title || '',
+      description: a.description || '',
+      thumbnailURL: this.api.thumbnailURL(a.id),
+    };
+  }
+
+  /**
+   * Fetch a page of assets for an album and return them as view models.
+   * Does not touch the store — the view appends them incrementally to
+   * avoid re-rendering the full grid (which would reset scroll).
+   */
+  async loadAssetsPage(id, { offset, limit }) {
+    const album = await this.api.getAlbum(id, { offset, limit });
+    const assets = (album.assets || []).map(a => this._assetToViewModel(a));
+    const total = typeof album.total_assets === 'number' ? album.total_assets : (offset + assets.length);
+    return { assets, total };
+  }
 }

--- a/frontend/src/core/index.js
+++ b/frontend/src/core/index.js
@@ -57,7 +57,10 @@ export function init(registry, container, siteConfig = {}) {
       activeRenderer.destroy();
     }
     activeRenderer = renderer;
-    renderer.render(container, state.viewModel, { store, router, session, permissions, features, popularity });
+    renderer.render(container, state.viewModel, {
+      store, router, session, permissions, features, popularity,
+      albumController: albumCtrl,
+    });
   });
 
   // Routes

--- a/frontend/src/ui-default/styles/main.css
+++ b/frontend/src/ui-default/styles/main.css
@@ -141,6 +141,13 @@ body {
   object-fit: cover;
 }
 
+.asset-grid-sentinel {
+  text-align: center;
+  padding: 1.5rem 0;
+  color: #888;
+  font-size: 0.9rem;
+}
+
 /* Asset viewer */
 .asset-viewer {
   max-width: 900px;

--- a/frontend/src/ui-default/views/album.js
+++ b/frontend/src/ui-default/views/album.js
@@ -8,7 +8,17 @@
 import { esc } from '../util/html.js';
 import { renderNav } from '../util/nav.js';
 
+// Page size for lazy-loaded asset chunks. Matches the backend default.
+const PAGE_SIZE = 100;
+
+// Holds cleanup for the current render so destroy() can tear down the
+// infinite-scroll observer without leaking listeners across views.
+let cleanup = null;
+
 export function render(container, viewModel, ctx) {
+  // Tear down any previous render's observer before we replace innerHTML.
+  destroy();
+
   if (!viewModel) {
     container.innerHTML = '<div class="loading">Loading\u2026</div>';
     return;
@@ -55,11 +65,13 @@ export function render(container, viewModel, ctx) {
   if (viewModel.assets && viewModel.assets.length > 0) {
     html += '<section class="asset-grid">';
     for (const asset of viewModel.assets) {
-      html += `<a href="#/assets/${esc(asset.id)}" class="asset-thumb">` +
-        `<img src="${esc(asset.thumbnailURL)}" alt="${esc(asset.title || asset.filename)}" loading="lazy">` +
-        '</a>';
+      html += assetThumbHTML(asset);
     }
     html += '</section>';
+    const total = viewModel.totalAssets || viewModel.assets.length;
+    if (viewModel.assets.length < total) {
+      html += '<div class="asset-grid-sentinel" aria-hidden="true">Loading more…</div>';
+    }
   }
 
   if ((!viewModel.children || viewModel.children.length === 0) &&
@@ -69,6 +81,8 @@ export function render(container, viewModel, ctx) {
 
   container.innerHTML = html;
   nav.setup(container);
+
+  setupInfiniteScroll(container, viewModel, ctx);
 
   // Wire up edit form
   const editBtn = container.querySelector('.album-edit-meta');
@@ -119,4 +133,100 @@ export function render(container, viewModel, ctx) {
   }
 }
 
-export function destroy() {}
+export function destroy() {
+  if (cleanup) {
+    cleanup();
+    cleanup = null;
+  }
+}
+
+function assetThumbHTML(asset) {
+  return `<a href="#/assets/${esc(asset.id)}" class="asset-thumb">` +
+    `<img src="${esc(asset.thumbnailURL)}" alt="${esc(asset.title || asset.filename)}" loading="lazy">` +
+    '</a>';
+}
+
+// setupInfiniteScroll wires an IntersectionObserver on the sentinel below
+// the asset grid. Each time it becomes visible, the next page of assets
+// is fetched and appended to the grid in place — no full re-render, so
+// scroll position and DOM state are preserved.
+function setupInfiniteScroll(container, viewModel, ctx) {
+  const grid = container.querySelector('.asset-grid');
+  const sentinel = container.querySelector('.asset-grid-sentinel');
+  if (!grid || !sentinel) return;
+
+  const total = viewModel.totalAssets || viewModel.assets.length;
+  let loaded = viewModel.assets.length;
+  let loading = false;
+
+  if (loaded >= total) {
+    sentinel.remove();
+    return;
+  }
+
+  // If no controller is available (e.g. a stripped ctx from a site override),
+  // there is no way to fetch more — drop the sentinel silently.
+  if (!ctx || !ctx.albumController || typeof ctx.albumController.loadAssetsPage !== 'function') {
+    sentinel.remove();
+    return;
+  }
+
+  // Fallback for environments without IntersectionObserver (older browsers,
+  // jsdom): fetch pages eagerly so no assets are hidden.
+  if (typeof IntersectionObserver === 'undefined') {
+    void fetchAll();
+    return;
+  }
+
+  const observer = new IntersectionObserver(async (entries) => {
+    if (!entries.some(e => e.isIntersecting) || loading) return;
+    await fetchNext();
+  }, { rootMargin: '400px 0px' });
+
+  observer.observe(sentinel);
+
+  cleanup = () => {
+    observer.disconnect();
+  };
+
+  async function fetchNext() {
+    if (loading || loaded >= total) return;
+    loading = true;
+    try {
+      const { assets, total: newTotal } = await ctx.albumController.loadAssetsPage(
+        viewModel.id,
+        { offset: loaded, limit: PAGE_SIZE }
+      );
+      appendAssets(assets);
+      loaded += assets.length;
+      // Server may have returned a larger total than we knew; respect it.
+      const cap = Math.max(newTotal, total);
+      if (loaded >= cap || assets.length === 0) {
+        observer.disconnect();
+        sentinel.remove();
+      }
+    } catch (err) {
+      // Leave the sentinel visible so the user (or a retry) can try again.
+      sentinel.textContent = 'Failed to load more. Scroll to retry.';
+      console.warn('gollery: failed to load more assets', err);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function fetchAll() {
+    while (loaded < total) {
+      // eslint-disable-next-line no-await-in-loop
+      await fetchNext();
+    }
+  }
+
+  function appendAssets(assets) {
+    if (!assets || assets.length === 0) return;
+    const frag = document.createDocumentFragment();
+    const tmp = document.createElement('div');
+    tmp.innerHTML = assets.map(assetThumbHTML).join('');
+    while (tmp.firstChild) frag.appendChild(tmp.firstChild);
+    grid.appendChild(frag);
+  }
+}

--- a/frontend/test/controllers.test.js
+++ b/frontend/test/controllers.test.js
@@ -89,6 +89,46 @@ describe('AlbumController', () => {
     assert.equal(store.get().viewModel.id, 'alb_vac');
   });
 
+  it('showAlbum surfaces total_assets on view model', async () => {
+    const store = new Store();
+    const api = fakeApi({
+      getAlbum: async (id) => ({
+        id, title: 'Big', path: 'big', children: [],
+        assets: [{ id: 'ast_1', filename: 'a.jpg' }],
+        total_assets: 350,
+      }),
+    });
+    const ctrl = new AlbumController(api, store);
+    await ctrl.showAlbum('alb_big');
+    assert.equal(store.get().viewModel.totalAssets, 350);
+    assert.equal(store.get().viewModel.assets.length, 1);
+  });
+
+  it('loadAssetsPage forwards offset/limit and maps assets', async () => {
+    const calls = [];
+    const api = fakeApi({
+      getAlbum: async (id, opts) => {
+        calls.push({ id, opts });
+        return {
+          id, title: 'X', path: '', children: [],
+          assets: [
+            { id: 'ast_100', filename: '100.jpg' },
+            { id: 'ast_101', filename: '101.jpg' },
+          ],
+          total_assets: 250,
+        };
+      },
+    });
+    const ctrl = new AlbumController(api, new Store());
+    const result = await ctrl.loadAssetsPage('alb_big', { offset: 100, limit: 100 });
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].opts, { offset: 100, limit: 100 });
+    assert.equal(result.total, 250);
+    assert.equal(result.assets.length, 2);
+    assert.equal(result.assets[0].id, 'ast_100');
+    assert.equal(result.assets[0].thumbnailURL, '/thumb/ast_100');
+  });
+
   it('showRoot handles 401', async () => {
     const store = new Store();
     const api = fakeApi({


### PR DESCRIPTION
Album view was silently truncated to the first 100 assets because the frontend called /albums/{id} without paginating and ignored the total_assets field in the response. Now the album view renders the first page, then lazily fetches successive pages of 100 assets each as the user scrolls near the bottom, appending tiles to the grid in place.

The append path avoids re-rendering the whole view so scroll position and DOM listeners survive. An IntersectionObserver watches a sentinel below the grid; the observer is torn down on view change via destroy() and falls back to eager fetching in environments without the observer.